### PR TITLE
Remove C-style for loops, unused code and return values

### DIFF
--- a/iSimulatorExplorer/DCImportCertificateWindowController.swift
+++ b/iSimulatorExplorer/DCImportCertificateWindowController.swift
@@ -101,7 +101,7 @@ class DCImportCertificateWindowController: NSWindowController, NSWindowDelegate,
                 let certCount = SecTrustGetCertificateCount(serverTrust)
                 NSLog("number certificate in serverTrust: \(certCount)");
                 
-                for var index = 0; index < certCount; index++ {
+                for index in 0 ..< certCount {
                     if let serverCertificate = SecTrustGetCertificateAtIndex(serverTrust, index) {
                         
                         let summary = SecCertificateCopySubjectSummary(serverCertificate)

--- a/iSimulatorExplorer/DCSimulator.swift
+++ b/iSimulatorExplorer/DCSimulator.swift
@@ -97,7 +97,7 @@ class Simulator {
                 format: nil)
             {
             if let plist = plistobj as? Dictionary<String, AnyObject> {
-                let deviceType = plist["deviceType"] as? String
+                //let deviceType = plist["deviceType"] as? String
                 let name1 = plist["name"] as? String
                 if let runtime = plist["runtime"] as? String {
                     version = runtime.componentsSeparatedByString(".").last

--- a/iSimulatorExplorer/DCSimulatorManager.swift
+++ b/iSimulatorExplorer/DCSimulatorManager.swift
@@ -111,7 +111,7 @@ class DCSimulatorManager {
         if simDeviceSet != nil  {
             if let deviceList = simDeviceSet!.availableDevices {
                 for simDevice in deviceList {
-                    var sim = Simulator(device: simDevice)
+                    let sim = Simulator(device: simDevice)
                     if sim.isValid {
                         simulators.append(sim)
                     }
@@ -134,7 +134,7 @@ class DCSimulatorManager {
                 
                 let path = (simBasePath as NSString).stringByAppendingPathComponent(item)
                 
-                var sim = Simulator(path: path)
+                let sim = Simulator(path: path)
                 if sim.isValid {
                     simulators.append(sim);
                 }

--- a/iSimulatorExplorer/DCSimulatorTrustStore.swift
+++ b/iSimulatorExplorer/DCSimulatorTrustStore.swift
@@ -77,7 +77,7 @@ class DCSimulatorTruststoreItem {
     
     func calcSHA1(data : NSData) -> NSData {
         
-        var digest = NSMutableData(length: Int(CC_SHA1_DIGEST_LENGTH))
+        let digest = NSMutableData(length: Int(CC_SHA1_DIGEST_LENGTH))
         CC_SHA1(data.bytes, CC_LONG(data.length), UnsafeMutablePointer<UInt8>(digest!.mutableBytes))
         return digest!
     }
@@ -90,7 +90,7 @@ class DCSimulatorTruststoreItem {
     func hexstringFromData(data : NSData) -> String {
         var dataBytes = UnsafePointer<UInt8>(data.bytes)
         var str : String = ""
-        for var i = 0; i < data.length; i++ {
+        for _ in 0 ..< data.length {
             dataBytes.memory
             str += NSString(format: "%02x", dataBytes.memory) as String
             dataBytes = dataBytes.successor()

--- a/iSimulatorExplorer/DCSimulatorTrustStoreViewController.swift
+++ b/iSimulatorExplorer/DCSimulatorTrustStoreViewController.swift
@@ -135,7 +135,7 @@ class DCSimulatorTrustStoreViewController: DCSimulatorViewController, NSTableVie
                     var outItems : CFArray?
                     //var outItems : UnsafeMutablePointer<CFArray?>
                     
-                    let status = SecItemImport(data, nil, &format, &itemType, SecItemImportExportFlags(rawValue: 0), nil, nil, &outItems)
+                    SecItemImport(data, nil, &format, &itemType, SecItemImportExportFlags(rawValue: 0), nil, nil, &outItems)
                     //if let itemCFArray = outItems?.takeRetainedValue() {
                     if let itemCFArray = outItems {
                         let itemArray = itemCFArray as NSArray


### PR DESCRIPTION
In order to remove warnings when compiling with Xcode 7.3, I have removed the C-style for loops (including the deprecated ++ operators), some unused code and some unused return values.
